### PR TITLE
Add assertions to TaskList operations

### DIFF
--- a/src/main/java/samson/task/TaskList.java
+++ b/src/main/java/samson/task/TaskList.java
@@ -47,6 +47,8 @@ public class TaskList {
      * @return The task that was removed.
      */
     public Task deleteTask(int index) {
+        assert index >= 0 && index < tasks.size() : "Index out of bounds: " + index;
+
         Task removedTask = tasks.remove(index);
         this.index--;
         return removedTask;


### PR DESCRIPTION
Use assert feature (not JUnit assertions) to document important assumptions that should hold at various points in the code.

To validate the task index to prevent over-indexing.